### PR TITLE
Test: Add testing of correctly passing parameter

### DIFF
--- a/tests/unittest/test_ai_model_integration.py
+++ b/tests/unittest/test_ai_model_integration.py
@@ -34,6 +34,7 @@ class TestGenerateContentTimeout(unittest.TestCase):
         with self.assertRaises(TimeoutException):
             generate_content_timeout(mock_model_instance, "Test prompt")
 
+
 class TestGetAnalysis(unittest.TestCase):
 
     @patch("app.generate_content_timeout", side_effect=google_exceptions.InvalidArgument("Invalid"))
@@ -51,6 +52,29 @@ class TestGetAnalysis(unittest.TestCase):
             get_analysis("Test prompt")
         except TimeoutException as e:
             self.fail(f"get_analysis raised {e} unexpectedly!")
+
+    @patch("app.generate_content_timeout")
+    @patch("PIL.Image.open")
+    @patch("app.genai.GenerativeModel")  # Mock model instance
+    def test_get_analysis_args_passing(self, mock_gen_model, mock_image_open, mock_generate_content):
+        """
+        Test whether get_analysis correctly passes model, prompt, and image arguments to generate_content_timeout.
+        """
+        mock_image = MagicMock()
+        mock_image_open.return_value = mock_image
+
+        # Mock model instance
+        mock_model_instance = MagicMock()
+        mock_gen_model.return_value = mock_model_instance
+
+        prompt = "Test prompt"
+        image_path = "test_image.jpg"
+
+        # Call get_analysis function
+        get_analysis(prompt, image_path)
+
+        # Verify the parameters received by generate_content_timeout
+        mock_generate_content.assert_called_once_with(mock_model_instance, prompt, mock_image)
 
 
 class TestFileUtils(unittest.TestCase):
@@ -89,3 +113,8 @@ class TestMainFunction(unittest.TestCase):
             main()
             mocked_print.assert_any_call("AI Analysis Result:")
             mocked_print.assert_any_call("Generated content")
+
+    
+  
+
+


### PR DESCRIPTION
### Purpose
Adds a unit test for the `get_analysis` function to ensure that it correctly passes the model, prompt, and image parameters to the `generate_content_timeout` function.

### Changes
- Added a test that mocks the `PIL.Image.open`, `app.genai.GenerativeModel`, and `app.generate_content_timeout` functions.
- The test verifies that `generate_content_timeout` is called with the appropriate arguments: the model instance, the prompt, and the opened image.